### PR TITLE
Fix incorrect editor style name for Unity 2022.3+

### DIFF
--- a/Editor/DropdownStyle.cs
+++ b/Editor/DropdownStyle.cs
@@ -53,12 +53,11 @@
         {
             get
             {
-                #if UNITY_2022_3_OR_NEWER
-                const string styleName = "ToolbarSearchTextField";
-                #else
-                const string styleName = "ToolbarSeachTextField";
-                #endif
-                return _searchToolbarStyle ?? (_searchToolbarStyle = new GUIStyle(GUI.skin.FindStyle(styleName)));
+				if (_searchToolbarStyle == null) {
+					GUIStyle original = GUI.skin.FindStyle("ToolbarSearchTextField") ?? GUI.skin.FindStyle("ToolbarSeachTextField");
+					_searchToolbarStyle = new GUIStyle(original);
+				}
+                return _searchToolbarStyle;
             }
         }
 

--- a/Editor/DropdownStyle.cs
+++ b/Editor/DropdownStyle.cs
@@ -49,8 +49,18 @@
 
         private static GUIStyle _searchToolbarStyle;
 
-        public static GUIStyle SearchToolbarStyle =>
-            _searchToolbarStyle ?? (_searchToolbarStyle = new GUIStyle(GUI.skin.FindStyle("ToolbarSeachTextField")));
+        public static GUIStyle SearchToolbarStyle
+        {
+            get
+            {
+                #if UNITY_2022_3_OR_NEWER
+                const string styleName = "ToolbarSearchTextField";
+                #else
+                const string styleName = "ToolbarSeachTextField";
+                #endif
+                return _searchToolbarStyle ?? (_searchToolbarStyle = new GUIStyle(GUI.skin.FindStyle(styleName)));
+            }
+        }
 
         private static readonly Color HighlightedColorDarkSkin = new Color(1f, 1f, 1f, 0.028f);
         private static readonly Color HighlightedColorLightSkin = new Color(1f, 1f, 1f, 0.3f);


### PR DESCRIPTION
In Unity 2022.3 they fixed typo in style name.
https://github.com/Unity-Technologies/UnityCsReference/commit/da51b77dce790fa867436bec018bfd56e464cec4#diff-d4e399fabac0c73f6f6580b4c4094492ab460619fb45fe621764230982beefd3

Same problem in SolidUtilities: https://github.com/SolidAlloy/SolidUtilities/pull/9